### PR TITLE
ConnectionManager: Clear ETag value on exception

### DIFF
--- a/core/src/main/kotlin/com/kynetics/updatefactory/ddiclient/core/actors/ConnectionManager.kt
+++ b/core/src/main/kotlin/com/kynetics/updatefactory/ddiclient/core/actors/ConnectionManager.kt
@@ -145,7 +145,7 @@ private constructor(scope: ActorScope) : AbstractActor(scope) {
             val errorDetails = "exception: ${t.javaClass} message: ${loopMsg(t)}"
             this.send(ErrMsg(errorDetails), state)
             LOG.warn(t.message, t)
-            become(runningReceive(startPing(s.nextBackoff())))
+            become(runningReceive(startPing(s.copy(controllerBaseEtag = "", deploymentEtag = ""))))
             notificationManager.send(MessageListener.Message.Event.Error(listOf(errorDetails)))
         }
     }


### PR DESCRIPTION
This commit fixes the https://github.com/Kynetics/uf-ddiclient/issues/1 issue.